### PR TITLE
Fixes for Unix/Linux systems

### DIFF
--- a/TrrntZipCMD/TrrntZipCMD.csproj
+++ b/TrrntZipCMD/TrrntZipCMD.csproj
@@ -54,7 +54,7 @@
       <Project>{ff8a7a0a-6319-49e0-a6e6-df3754bffdd1}</Project>
       <Name>RVIO</Name>
     </ProjectReference>
-    <ProjectReference Include="..\trrntzip\Trrntzip.csproj">
+    <ProjectReference Include="..\Trrntzip\Trrntzip.csproj">
       <Project>{21822412-a4ce-4a55-bd41-aaea753753f1}</Project>
       <Name>Trrntzip</Name>
     </ProjectReference>

--- a/TrrntZipUI/TrrntZipUI.csproj
+++ b/TrrntZipUI/TrrntZipUI.csproj
@@ -123,7 +123,7 @@
       <Project>{ff8a7a0a-6319-49e0-a6e6-df3754bffdd1}</Project>
       <Name>RVIO</Name>
     </ProjectReference>
-    <ProjectReference Include="..\trrntzip\Trrntzip.csproj">
+    <ProjectReference Include="..\Trrntzip\Trrntzip.csproj">
       <Project>{21822412-a4ce-4a55-bd41-aaea753753f1}</Project>
       <Name>Trrntzip</Name>
     </ProjectReference>

--- a/Trrntzip/TorrentZipRebuild.cs
+++ b/Trrntzip/TorrentZipRebuild.cs
@@ -34,10 +34,10 @@ namespace Trrntzip
             int bufferSize = buffer.Length;
 
             string filename = originalZipFile.ZipFilename;
-            string tmpFilename = Path.GetDirectoryName(filename) + Path.DirectorySeparatorChar + Path.GetFileNameWithoutExtension(filename) + ".tmp";
+            string tmpFilename = Path.Combine(Path.GetDirectoryName(filename),Path.GetFileNameWithoutExtension(filename) + ".tmp");
 
             string outExt = outputType == zipType.zip ? ".zip" : ".7z";
-            string outfilename = Path.GetDirectoryName(filename) + Path.DirectorySeparatorChar + Path.GetFileNameWithoutExtension(filename) + outExt;
+            string outfilename = Path.Combine(Path.GetDirectoryName(filename), Path.GetFileNameWithoutExtension(filename) + outExt);
 
             if (inputType != outputType)
             {


### PR DESCRIPTION
Some fixes for Unix/Linux systems:

- Fix case to allows Visual Studio Code to find project PATH as systems are case sensitives.
- Use Path.Combine instead of concatenation of Path.DirectorySeparatorChar in Trrntzip to avoid '\' instead of '/' as directory separator and thus creating 'foo\bar' file instead of the file bar in the foo directory when torrentziping files on Unix systems.