### PR TITLE
RVCmd: ProgressChanged reports with strings now displays correctly

### DIFF
--- a/RVCmd/Program.cs
+++ b/RVCmd/Program.cs
@@ -206,6 +206,11 @@ namespace RVCmd
             {
                 return;
             }
+            if (e is string message)
+            {
+                Console.WriteLine(message);
+                return;
+            }
 
             Console.WriteLine($"Unknown report type {e.GetType()}");
         }


### PR DESCRIPTION
Added a small fix to allow pure string reports as part of the BgwProgressChanged event.
This is today mainly for the `Saving Cache` and `Saving Cache Complete` messages which in current versions returns `Unknown report type System.String`.