### PR TITLE
Cosmetic fixes to game and rom list output

### DIFF
--- a/ROMVault/FrmMain_GameGrid.cs
+++ b/ROMVault/FrmMain_GameGrid.cs
@@ -149,8 +149,6 @@ namespace ROMVault
             }
 
             _updatingGameGrid = false;
-
-            UpdateSelectedGame();
         }
 
         private static int DigitLength(int number)
@@ -266,9 +264,11 @@ namespace ROMVault
                     if (tRvDir.Game != null)
                     {
                         e.Value = tRvDir.Game.GetData(RvGame.GameData.Description);
-                    }
+					} else if (tRvDir.Dat != null) {
+						e.Value = tRvDir.Dat.GetData(RvDat.DatData.Description);
+					}
 
-                    break;
+					break;
                 case 3: // CCorrect
                     {
                         Bitmap bmp = new Bitmap(GameGrid.Columns[3].Width, 18);

--- a/ROMVault/FrmMain_RomGrid.cs
+++ b/ROMVault/FrmMain_RomGrid.cs
@@ -89,26 +89,14 @@ namespace ROMVault
             {
                 RvFile tBase = tGame.Child(l);
 
-                RvFile tFile = tBase;
-                if (tFile.IsFile)
+                if (tBase.IsFile)
                 {
-                    AddRom(tFile, pathAdd, ref fileList);
+                    AddRom(tBase, pathAdd, ref fileList);
                 }
 
-                if (tGame.Dat == null)
+                if (tBase.IsDir)
                 {
-                    continue;
-                }
-
-                RvFile tDir = tBase;
-                if (!tDir.IsDir)
-                {
-                    continue;
-                }
-
-                if (tDir.Game == null)
-                {
-                    AddDir(tDir, pathAdd + tDir.Name + "/", ref fileList);
+                    AddDir(tBase, pathAdd + tBase.Name + "/", ref fileList);
                 }
             }
         }


### PR DESCRIPTION
Some minor cosmetic fixes while getting acquainted with the code: 

* If there is no game description attempt to display dat description in game list.
* Drive rom list output from game list change event to only update when game selected.
* Output roms for selected game recursively with path modified as intended.

The master branch is not currently up to date (latest V3.4.5) and it will make merging more complex changes much more manageable if we rather patch against the latest source. Will gladly rebase this branch if master is updated.