### PR TITLE
Fix: avoid crashes on zip IO errors

### DIFF
--- a/Compress/ZipFile/Zip.cs
+++ b/Compress/ZipFile/Zip.cs
@@ -116,7 +116,13 @@ namespace Compress.ZipFile
 
         ~Zip()
         {
-            ZipFileClose();
+            try
+            {
+                ZipFileCloseFailed();
+            }
+            catch
+            {
+            }
         }
 
 

--- a/Compress/ZipFile/ZipOpenWrite.cs
+++ b/Compress/ZipFile/ZipOpenWrite.cs
@@ -1,4 +1,4 @@
-﻿using Compress.Support.Utils;
+using Compress.Support.Utils;
 using System.IO;
 using FileInfo = RVIO.FileInfo;
 using FileStream = RVIO.FileStream;
@@ -98,28 +98,33 @@ namespace Compress.ZipFile
 
         public void ZipFileCloseFailed()
         {
-            switch (ZipOpen)
+            try
             {
-                case ZipOpenType.Closed:
-                    return;
-                case ZipOpenType.OpenRead:
-                    if (_zipFs != null)
-                    {
-                        _zipFs.Close();
-                        _zipFs.Dispose();
-                    }
-                    break;
-                case ZipOpenType.OpenWrite:
-                    _zipFs.Flush();
-                    _zipFs.Close();
-                    _zipFs.Dispose();
-                    if (_zipFileInfo != null)
-                        RVIO.File.Delete(_zipFileInfo.FullName);
-                    _zipFileInfo = null;
-                    break;
+                switch (ZipOpen)
+                {
+                    case ZipOpenType.Closed:
+                        return;
+                    case ZipOpenType.OpenRead:
+                        try { _zipFs?.Close(); } catch { }
+                        try { _zipFs?.Dispose(); } catch { }
+                        break;
+                    case ZipOpenType.OpenWrite:
+                        try { _zipFs?.Flush(); } catch { }
+                        try { _zipFs?.Close(); } catch { }
+                        try { _zipFs?.Dispose(); } catch { }
+                        if (_zipFileInfo != null)
+                        {
+                            try { RVIO.File.Delete(_zipFileInfo.FullName); } catch { }
+                        }
+                        _zipFileInfo = null;
+                        break;
+                }
             }
-
-            ZipOpen = ZipOpenType.Closed;
+            finally
+            {
+                _zipFs = null;
+                ZipOpen = ZipOpenType.Closed;
+            }
         }
 
     }

--- a/RomVaultCore/FixFile/FixAZip.cs
+++ b/RomVaultCore/FixFile/FixAZip.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -509,6 +509,13 @@ namespace RomVaultCore.FixFile
                 ReportError.procLog($"FixAZip: Error Exception, nulling out.");
 
                 errorMessage = "In Fix Zip:\n" + ex.Message + "\nat\n:" + ex.StackTrace;
+                Exception checkEx = ex;
+                while (checkEx != null)
+                {
+                    if (checkEx is System.IO.IOException)
+                        return ReturnCode.FileSystemError;
+                    checkEx = checkEx.InnerException;
+                }
                 return ReturnCode.LogicError;
             }
             finally


### PR DESCRIPTION
Should prevent the hardcrash Braintrash reported on Discord.

- Treat IOException during FixAZip as FileSystemError so fix passes report and continue

- Harden Zip finalizer/failed-close paths to never throw during GC